### PR TITLE
Standardizes css class nomenclatures/ use BEM

### DIFF
--- a/__test__/__snapshots__/component.spec.js.snap
+++ b/__test__/__snapshots__/component.spec.js.snap
@@ -6,7 +6,7 @@ exports[`Toast component renders when active 1`] = `
   leaveactiveclass="v-toast--fade-out"
 >
   <div
-    class="v-toast v-toast--success v-toast--bottom-right"
+    class="v-toast__item v-toast__item--success v-toast__item--bottom-right"
     role="alert"
     style=""
   >

--- a/__test__/__snapshots__/component.spec.js.snap
+++ b/__test__/__snapshots__/component.spec.js.snap
@@ -2,20 +2,20 @@
 
 exports[`Toast component renders when active 1`] = `
 <transition-stub
-  enteractiveclass="fadeInUp"
-  leaveactiveclass="fadeOut"
+  enteractiveclass="v-toast--fade-in-up"
+  leaveactiveclass="v-toast--fade-out"
 >
   <div
-    class="v-toast v-toast-success is-bottom-right"
+    class="v-toast v-toast--success v-toast--bottom-right"
     role="alert"
     style=""
   >
     <div
-      class="v-toast-icon"
+      class="v-toast__icon"
     />
      
     <p
-      class="v-toast-text"
+      class="v-toast__text"
     >
       Test message
     </p>

--- a/__test__/__snapshots__/plugin.spec.js.snap
+++ b/__test__/__snapshots__/plugin.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Toast plugin has close method on instance returned by open() 1`] = `
 <div
-  class="v-toast v-toast--success v-toast--bottom-right v-enter v-toast--fade-in-up"
+  class="v-toast__item v-toast__item--success v-toast__item--bottom-right v-enter v-toast--fade-in-up"
   role="alert"
   style=""
 >

--- a/__test__/__snapshots__/plugin.spec.js.snap
+++ b/__test__/__snapshots__/plugin.spec.js.snap
@@ -2,16 +2,16 @@
 
 exports[`Toast plugin has close method on instance returned by open() 1`] = `
 <div
-  class="v-toast v-toast-success is-bottom-right v-enter fadeInUp"
+  class="v-toast v-toast--success v-toast--bottom-right v-enter v-toast--fade-in-up"
   role="alert"
   style=""
 >
   <div
-    class="v-toast-icon"
+    class="v-toast__icon"
   />
    
   <p
-    class="v-toast-text"
+    class="v-toast__text"
   >
     <b>
       Sample

--- a/src/js/Component.vue
+++ b/src/js/Component.vue
@@ -6,12 +6,12 @@
       role="alert"
       v-show="isActive"
       class="v-toast"
-      :class="[`v-toast-${type}`, `is-${position}`]"
+      :class="[`v-toast--${type}`, `v-toast--${position}`]"
       @mouseover="toggleTimer(true)"
       @mouseleave="toggleTimer(false)"
       @click="whenClicked">
-      <div class="v-toast-icon"></div>
-      <p class="v-toast-text" v-html="message"></p>
+      <div class="v-toast__icon"></div>
+      <p class="v-toast__text" v-html="message"></p>
     </div>
   </transition>
 </template>
@@ -81,19 +81,19 @@
     },
     methods: {
       setupContainer() {
-        this.parentTop = document.querySelector('.v-notices.is-top');
-        this.parentBottom = document.querySelector('.v-notices.is-bottom');
+        this.parentTop = document.querySelector('.v-toast__container.v-toast__container--top');
+        this.parentBottom = document.querySelector('.v-toast__container.v-toast__container--bottom');
         // No need to create them, they already exists
         if (this.parentTop && this.parentBottom) return;
 
         if (!this.parentTop) {
           this.parentTop = document.createElement('div');
-          this.parentTop.className = 'v-notices is-top';
+          this.parentTop.className = 'v-toast__container v-toast__container--top';
         }
 
         if (!this.parentBottom) {
           this.parentBottom = document.createElement('div');
-          this.parentBottom.className = 'v-notices is-bottom'
+          this.parentBottom.className = 'v-toast__container v-toast__container--bottom'
         }
 
         const container = document.body;
@@ -165,16 +165,16 @@
           case Positions.TOP_RIGHT:
           case Positions.TOP_LEFT:
             return {
-              enter: 'fadeInDown',
-              leave: 'fadeOut'
+              enter: 'v-toast--fade-in-down',
+              leave: 'v-toast--fade-out'
             };
 
           case Positions.BOTTOM:
           case Positions.BOTTOM_RIGHT:
           case Positions.BOTTOM_LEFT:
             return {
-              enter: 'fadeInUp',
-              leave: 'fadeOut'
+              enter: 'v-toast--fade-in-up',
+              leave: 'v-toast--fade-out'
             }
         }
       },

--- a/src/js/Component.vue
+++ b/src/js/Component.vue
@@ -5,8 +5,8 @@
     <div
       role="alert"
       v-show="isActive"
-      class="v-toast"
-      :class="[`v-toast--${type}`, `v-toast--${position}`]"
+      class="v-toast__item"
+      :class="[`v-toast__item--${type}`, `v-toast__item--${position}`]"
       @mouseover="toggleTimer(true)"
       @mouseleave="toggleTimer(false)"
       @click="whenClicked">
@@ -81,19 +81,19 @@
     },
     methods: {
       setupContainer() {
-        this.parentTop = document.querySelector('.v-toast__container.v-toast__container--top');
-        this.parentBottom = document.querySelector('.v-toast__container.v-toast__container--bottom');
+        this.parentTop = document.querySelector('.v-toast.v-toast--top');
+        this.parentBottom = document.querySelector('.v-toast.v-toast--bottom');
         // No need to create them, they already exists
         if (this.parentTop && this.parentBottom) return;
 
         if (!this.parentTop) {
           this.parentTop = document.createElement('div');
-          this.parentTop.className = 'v-toast__container v-toast__container--top';
+          this.parentTop.className = 'v-toast v-toast--top';
         }
 
         if (!this.parentBottom) {
           this.parentBottom = document.createElement('div');
-          this.parentBottom.className = 'v-toast__container v-toast__container--bottom'
+          this.parentBottom.className = 'v-toast v-toast--bottom'
         }
 
         const container = document.body;

--- a/src/themes/_animations.scss
+++ b/src/themes/_animations.scss
@@ -10,7 +10,7 @@
   }
 }
 
-.fadeOut {
+.v-toast--fade-out {
   animation-name: fadeOut;
 }
 
@@ -25,7 +25,7 @@
   }
 }
 
-.fadeInDown {
+.v-toast--fade-in-down {
   animation-name: fadeInDown;
 }
 
@@ -40,7 +40,7 @@
   }
 }
 
-.fadeInUp {
+.v-toast--fade-in-up {
   animation-name: fadeInUp;
 }
 

--- a/src/themes/default/_main.scss
+++ b/src/themes/default/_main.scss
@@ -1,4 +1,4 @@
-.v-notices {
+.v-toast__container {
   position: fixed;
   display: flex;
   top: 0;
@@ -23,49 +23,47 @@
     min-height: 3em;
     cursor: pointer;
 
-    .v-toast-text {
+    &__text {
       margin: 0;
       padding: 0.5em 1em;
       word-break: break-word;
     }
 
-    .v-toast-icon {
+    &__icon {
       display: none;
     }
-  }
 
-  // Colors
-  @each $color, $value in $toast-colors {
-    .v-toast-#{$color} {
-      background-color: $value;
+    // Colors
+    @each $color, $value in $toast-colors {
+      &--#{$color} {
+        background-color: $value;
+      }
     }
-  }
 
-  // Individual toast position
-  .v-toast {
-    &.is-top, &.is-bottom {
+    // Individual toast position
+    &.v-toast--top, &.v-toast--bottom {
       align-self: center;
     }
 
-    &.is-top-right, &.is-bottom-right {
+    &.v-toast--top-right, &.v-toast--bottom-right {
       align-self: flex-end;
     }
 
-    &.is-top-left, &.is-bottom-left {
+    &.v-toast--top-left, &.v-toast--bottom-left {
       align-self: flex-start;
     }
   }
 
   // Notice container positions
-  &.is-top {
+  &.v-toast__container--top {
     flex-direction: column;
   }
 
-  &.is-bottom {
+  &.v-toast__container--bottom {
     flex-direction: column-reverse;
   }
 
-  &.is-custom-parent {
+  &.v-toast__container--custom-parent {
     position: absolute;
   }
 

--- a/src/themes/default/_main.scss
+++ b/src/themes/default/_main.scss
@@ -1,4 +1,4 @@
-.v-toast__container {
+.v-toast {
   position: fixed;
   display: flex;
   top: 0;
@@ -10,7 +10,7 @@
   z-index: 1052;
   pointer-events: none;
 
-  .v-toast {
+  &__item {
     display: inline-flex;
     align-items: center;
     animation-duration: 150ms;
@@ -23,16 +23,6 @@
     min-height: 3em;
     cursor: pointer;
 
-    &__text {
-      margin: 0;
-      padding: 0.5em 1em;
-      word-break: break-word;
-    }
-
-    &__icon {
-      display: none;
-    }
-
     // Colors
     @each $color, $value in $toast-colors {
       &--#{$color} {
@@ -41,29 +31,39 @@
     }
 
     // Individual toast position
-    &.v-toast--top, &.v-toast--bottom {
+    &.v-toast__item--top, &.v-toast__item--bottom {
       align-self: center;
     }
 
-    &.v-toast--top-right, &.v-toast--bottom-right {
+    &.v-toast__item--top-right, &.v-toast__item--bottom-right {
       align-self: flex-end;
     }
 
-    &.v-toast--top-left, &.v-toast--bottom-left {
+    &.v-toast__item--top-left, &.v-toast__item--bottom-left {
       align-self: flex-start;
     }
   }
 
+  &__text {
+    margin: 0;
+    padding: 0.5em 1em;
+    word-break: break-word;
+  }
+
+  &__icon {
+    display: none;
+  }
+  
   // Notice container positions
-  &.v-toast__container--top {
+  &.v-toast--top {
     flex-direction: column;
   }
 
-  &.v-toast__container--bottom {
+  &.v-toast--bottom {
     flex-direction: column-reverse;
   }
 
-  &.v-toast__container--custom-parent {
+  &.v-toast--custom-parent {
     position: absolute;
   }
 

--- a/src/themes/sugar/icons.scss
+++ b/src/themes/sugar/icons.scss
@@ -1,5 +1,5 @@
-.v-toast__container {
-  .v-toast {
+.v-toast {
+  &__item {
     opacity: 1;
     min-height: 4em;
 
@@ -16,15 +16,15 @@
       background: url(./icons/info.svg) no-repeat;
     }
 
-    &.v-toast--success .v-toast__icon {
+    &.v-toast__item--success .v-toast__icon {
       background: url(./icons/success.svg) no-repeat;
     }
 
-    &.v-toast--error .v-toast__icon {
+    &.v-toast__item--error .v-toast__icon {
       background: url(./icons/error.svg) no-repeat;
     }
 
-    &.v-toast--warning .v-toast__icon {
+    &.v-toast__item--warning .v-toast__icon {
       background: url(./icons/warning.svg) no-repeat;
     }
   }

--- a/src/themes/sugar/icons.scss
+++ b/src/themes/sugar/icons.scss
@@ -1,13 +1,13 @@
-.v-notices {
+.v-toast__container {
   .v-toast {
     opacity: 1;
     min-height: 4em;
 
-    .v-toast-text {
+    .v-toast__text {
       padding: 1.5em 1em;
     }
 
-    .v-toast-icon {
+    .v-toast__icon {
       display: block;
       width: 27px;
       min-width: 27px;
@@ -16,15 +16,15 @@
       background: url(./icons/info.svg) no-repeat;
     }
 
-    &.v-toast-success .v-toast-icon {
+    &.v-toast--success .v-toast__icon {
       background: url(./icons/success.svg) no-repeat;
     }
 
-    &.v-toast-error .v-toast-icon {
+    &.v-toast--error .v-toast__icon {
       background: url(./icons/error.svg) no-repeat;
     }
 
-    &.v-toast-warning .v-toast-icon {
+    &.v-toast--warning .v-toast__icon {
       background: url(./icons/warning.svg) no-repeat;
     }
   }


### PR DESCRIPTION
As commented by @LanFeusT23... it is important to standardize the prefix of the `vue-toast-notification` classes so that it is easier to apply a regex or similar rules

I used `v-toast` as prefix

https://github.com/ankurk91/vue-toast-notification/issues/31