### PR TITLE
Fix missing type definition for useToast export

### DIFF
--- a/types/toast.d.ts
+++ b/types/toast.d.ts
@@ -52,4 +52,6 @@ declare module '@vue/runtime-core' {
 
 declare const ToastPlugin: Plugin
 
+export const useToast: ToastPluginApi;
+
 export default ToastPlugin


### PR DESCRIPTION
This PR relates to this issue: https://github.com/ankurk91/vue-toast-notification/issues/58

It adds the currently perfectly working just undocumented `useToast` export to the `types/toast.d.ts` and thus allows using `useToast` in a Composition API component using TypeScript.