### PR TITLE
Split ToastProps interface to accommodate for different usage

### DIFF
--- a/types/toast.d.ts
+++ b/types/toast.d.ts
@@ -52,4 +52,14 @@ declare module '@vue/runtime-core' {
 
 declare const ToastPlugin: Plugin
 
+export function useToast(globalProps?: Partial<ToastProps>): {
+  open(options: string|Partial<ToastProps>): ActiveToast;
+  clear(): void;
+  success(message: string, options?: Partial<ToastProps>): ActiveToast;
+  error(message: string, options?: Partial<ToastProps>): ActiveToast;
+  info(message: string, options?: Partial<ToastProps>): ActiveToast;
+  warning(message: string, options?: Partial<ToastProps>): ActiveToast;
+  default(message: string, options?: Partial<ToastProps>): ActiveToast;
+};
+
 export default ToastPlugin

--- a/types/toast.d.ts
+++ b/types/toast.d.ts
@@ -14,8 +14,11 @@ export type ToastPosition =
 
 export type ToastType = 'success' | 'info' | 'error' | 'warning' | 'default'
 
+export interface ToastPropsWithMessage extends ToastProps {
+  message: string;
+}
+
 export interface ToastProps {
-  message: string,
   type?: ToastType | string,
   position?: ToastPosition,
   duration?: number,
@@ -29,7 +32,7 @@ export interface ToastProps {
 export interface ToastPluginApi {
   open(message: string): ActiveToast
 
-  open(options: ToastProps): ActiveToast
+  open(options: ToastPropsWithMessage): ActiveToast
 
   success(message: string, options?: ToastProps): ActiveToast
 
@@ -52,14 +55,6 @@ declare module '@vue/runtime-core' {
 
 declare const ToastPlugin: Plugin
 
-export function useToast(globalProps?: Partial<ToastProps>): {
-  open(options: string|Partial<ToastProps>): ActiveToast;
-  clear(): void;
-  success(message: string, options?: Partial<ToastProps>): ActiveToast;
-  error(message: string, options?: Partial<ToastProps>): ActiveToast;
-  info(message: string, options?: Partial<ToastProps>): ActiveToast;
-  warning(message: string, options?: Partial<ToastProps>): ActiveToast;
-  default(message: string, options?: Partial<ToastProps>): ActiveToast;
-};
+export function useToast(globalProps?: Partial<ToastProps>): ToastPluginApi;
 
 export default ToastPlugin


### PR DESCRIPTION
The current type definitions describe the ToastProps as an object which has to always contain a message property. 
Using any of the functions beside open then causes TypeScript to show an error.

Example Code:

```typescript
useToast().error('Some Error Message', { duration: 10000 });
```

> TS2345: Argument of type '{ duration: number; }' is not assignable to parameter of type 'ToastProps'.   Property 'message' is missing in type '{ duration: number; }' but required in type 'ToastProps'.  toast.d.ts(22, 3): 'message' is declared here.

In fact only the open function uses that message property, so I have split these into two different interfaces.
