### PR TITLE
Declare Module 'vue' instead of '@vue/runtime-core'

### DIFF
--- a/types/toast.d.ts
+++ b/types/toast.d.ts
@@ -47,7 +47,7 @@ export interface ToastPluginApi {
   clear(): void
 }
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   interface ComponentCustomProperties {
     readonly $toast: ToastPluginApi;
   }


### PR DESCRIPTION
augmenting via `declare module '@vue/runtime-core'` instead of `declare module 'vue'` started to break a lot of dependencies recently. Lets update vue-toast-notification too so its not breaking types for other dependencies.

see discussion here for example: https://github.com/vuejs/router/discussions/2321#discussioncomment-10240858

before PR:
<img width="1821" alt="image" src="https://github.com/user-attachments/assets/e07994fd-8a03-45b9-a6d5-9d03c6abcd3b">

after PR:
<img width="357" alt="image" src="https://github.com/user-attachments/assets/1b118a1d-0822-477e-b5ab-bd859920b9d1">
